### PR TITLE
Allow easy running from the command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,11 @@ snowjob
 
 A python script that allows your terminal to snow.
 
-You can find a bash(shell) script version of this here:
-https://gist.github.com/sontek/1505483
+```bash
+$ python -m snowjob
+```
 
 You can pass --stack if you want the snow to pile up
+
+You can find a bash(shell) script version of this here:
+https://gist.github.com/sontek/1505483

--- a/snowjob/__init__.py
+++ b/snowjob/__init__.py
@@ -112,7 +112,6 @@ def move_flake(col, stack):
 
         print("\033[1;1H")
 
-
 def main():
     if len(sys.argv) > 1:
         stack = sys.argv[1] == '--stack'
@@ -144,7 +143,3 @@ def main():
             move_flake(flake, stack)
 
         time.sleep(0.1)
-
-
-if __name__ == "__main__":
-    main()

--- a/snowjob/__init__.py
+++ b/snowjob/__init__.py
@@ -112,6 +112,7 @@ def move_flake(col, stack):
 
         print("\033[1;1H")
 
+
 def main():
     if len(sys.argv) > 1:
         stack = sys.argv[1] == '--stack'

--- a/snowjob/__main__.py
+++ b/snowjob/__main__.py
@@ -1,0 +1,5 @@
+import snowjob
+
+
+if __name__ == "__main__":
+    snowjob.main()


### PR DESCRIPTION
Allow the idiom

```bash
$ python -m snowjob
```

instead of having to write

```bash
$ python snowjob/__init__.py
```