### PR TITLE
Use official Python docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cgr.dev/chainguard/python:latest-dev
+FROM python:alpine
 WORKDIR /app
 COPY . .
 RUN pip install -e .


### PR DESCRIPTION
This allows more people to have festivities in their terminal with Docker if they choose so ;)

Official docker image is multi architecture. The currently used image is only for arm I believe. 

See also #18 

resolves #18 