### PR TITLE
Fix particle drawing in tree mode

### DIFF
--- a/snowmachine/__init__.py
+++ b/snowmachine/__init__.py
@@ -178,7 +178,7 @@ def tree(light_delay, color, lights_color, snow_color, particle, snow, snow_part
 
             # its already on the screen, move it
             if col in snowflakes.keys():
-                move_flake(snowflakes, current_rows, col, None, particle, snow_color)
+                move_flake(snowflakes, current_rows, col, None, snow_particle, snow_color)
             else:
                 # otherwise put it on the screen
                 flake = snow_particle if snow_particle else get_random_flake()
@@ -187,7 +187,7 @@ def tree(light_delay, color, lights_color, snow_color, particle, snow, snow_part
 
             # key any flakes on the screen moving
             for flake in snowflakes.keys():
-                move_flake(snowflakes, current_rows, flake, None, particle, snow_color)
+                move_flake(snowflakes, current_rows, flake, None, snow_particle, snow_color)
             ##### SNOW ######
 
         end = time.time()

--- a/snowmachine/__init__.py
+++ b/snowmachine/__init__.py
@@ -141,7 +141,7 @@ def tree(light_delay, color, lights_color, snow_color, particle, snow, snow_part
     treeparts = []
     trunkparts = []
 
-    particle = particle or get_random_flake()
+    particle = particle or '*'
 
     trunk_size = 3
     tree_rows = rows - trunk_size


### PR DESCRIPTION
These two commits address instances of accidentally treating leaf particles as snow particles.  Although commit 2f962f2e fixes a bug that would be uncommonly hit under normal usage, commit 1d082401 fixes as issue where the snow is eventually drawn using only leaf particles. Since the default leaf particle is an asterisk, which also looks OK as a snow particle, this bug may have gone unnoticed for a while.